### PR TITLE
Build debian trixie by default

### DIFF
--- a/features/base/exec.late
+++ b/features/base/exec.late
@@ -19,7 +19,11 @@ DRACUT_COMPRESS_XZ="$(command -v xz)" dracut \
 --reproducible \
 "/boot/initrd.img-$version"
 
-kernel-install add "$version" "$kernel"
+if ! command -v python3 > /dev/null; then
+	mkdir -p /etc/kernel/install.d
+	ln -s /usr/bin/true /etc/kernel/install.d/60-ukify.install
+fi
+SYSTEMD_ESP_PATH=/boot/efi kernel-install --verbose --entry-token literal:Default add "$version" "$kernel"
 
 sed 's/boot\/efi\///' -i /boot/efi/loader/entries/*.conf
 

--- a/get_version
+++ b/get_version
@@ -2,4 +2,4 @@
 
 set -eufo pipefail
 
-echo bookworm
+echo trixie


### PR DESCRIPTION
**What this PR does / why we need it**: Update the build to debian trixie (the new testing) distribution by default.
