### PR TITLE
Define builder version in dockerfile

### DIFF
--- a/build
+++ b/build
@@ -3,7 +3,7 @@
 set -euo pipefail
 shopt -s nullglob
 
-container_image=ghcr.io/gardenlinux/builder:8e513c0afda1db01b4b14b6d8245bb077fde210e
+container_image=localhost/builder
 container_engine=podman
 target_dir=.build
 
@@ -75,7 +75,14 @@ done
 
 if [ "$container_image" = localhost/builder ]; then
 	dir="$(dirname -- "$(realpath -- "${BASH_SOURCE[0]}")")"
-	"$container_engine" build -t "$container_image" "$dir"
+	# Build from 'builder.dockerfile' if that exists, otherwise the default file name will be 'Dockerfile' or 'Containerfile'.
+	# It is recommended to call the file 'builder.dockerfile' to make it's intention clear.
+	# That file might only contain a single line 'FROM ghcr.io/gardenlinux/builder:...' which can be updated via dependabot.
+	if [[ -f builder.dockerfile ]]; then
+		"$container_engine" build -t "$container_image" -f builder.dockerfile "$dir"
+	else
+		"$container_engine" build -t "$container_image" "$dir"
+	fi
 fi
 
 repo="$(./get_repo)"

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,0 +1,4 @@
+# This file intentionally only has the 'FROM' line.
+# Defining the builder version this way allows us to update it via dependabot which was not possible any other way.
+
+FROM ghcr.io/gardenlinux/builder:8e513c0afda1db01b4b14b6d8245bb077fde210e

--- a/builder.dockerfile
+++ b/builder.dockerfile
@@ -1,4 +1,3 @@
-# This file intentionally only has the 'FROM' line.
-# Defining the builder version this way allows us to update it via dependabot which was not possible any other way.
+# Dependency management via Dependabot
 
 FROM ghcr.io/gardenlinux/builder:8e513c0afda1db01b4b14b6d8245bb077fde210e


### PR DESCRIPTION
This change is needed to allow keeping the builder updated via dependabot.
