### PR TITLE
Build with ubuntu 24.04 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Build the image


### PR DESCRIPTION
Should fix https://github.com/actions/runner-images/issues/9425 by newer podman/crun dependencies

The ubuntu 24.04 runner is still in beta https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/

I'd merge this here now and wait with upgrading our main repos until the image is more mature.